### PR TITLE
deployments: fix default container & pod securityContext

### DIFF
--- a/charts/elasti/templates/deployment.yaml
+++ b/charts/elasti/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       containers:
-      - args: 
+      - args:
         {{- toYaml .Values.elastiController.manager.args | nindent 8 }}
         command:
         - /manager
@@ -61,12 +61,12 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources: 
+        resources:
           {{- toYaml .Values.elastiController.manager.resources | nindent 10 }}
-        securityContext: 
+        securityContext:
           {{- toYaml .Values.elastiController.manager.containerSecurityContext | nindent 10 }}
       securityContext:
-        runAsNonRoot: true
+        {{- toYaml .Values.elastiController.manager.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "elasti.fullname" . }}-operator-controller-manager
       terminationGracePeriodSeconds: 10
 ---
@@ -132,5 +132,9 @@ spec:
         ports:
         - containerPort: {{ .Values.elastiResolver.service.port }}
         - containerPort: {{ .Values.elastiResolver.reverseProxyService.port }}
-        resources: 
+        resources:
           {{- toYaml .Values.elastiResolver.proxy.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.elastiResolver.proxy.containerSecurityContext | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.elastiResolver.proxy.podSecurityContext | nindent 8 }}

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -12,9 +12,16 @@ elastiController:
       - --metrics-bind-address=0
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
       capabilities:
         drop:
           - ALL
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      seccompProfile:
+        type: RuntimeDefault
     image:
       repository: tfy.jfrog.io/tfy-images/elasti-operator
       tag: 94151d8361cbeb0b6f972dbc662b88dce6b12e35
@@ -64,6 +71,18 @@ elastiResolver:
       requests:
         cpu: 100m
         memory: 40Mi
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      seccompProfile:
+        type: RuntimeDefault
     sentry:
       enabled: false
       environment: ""


### PR DESCRIPTION
## Description
This sets new defaults for pod & container `securityContext` for both Resolve & Operator deployments.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [x] tested locally

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [x] A PR is open to update the helm chart (link)[https://github.com/truefoundry/elasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable security context settings for controller and resolver containers and pods, allowing for enhanced customization of security options.

* **Chores**
  * Improved security defaults by enforcing non-root execution, read-only root filesystems, and stricter seccomp profiles for containers.
  * Standardized formatting in deployment configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->