### PR TITLE
e2e: fix test issues

### DIFF
--- a/pkg/scaling/scalers/prometheus_scaler.go
+++ b/pkg/scaling/scalers/prometheus_scaler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -65,9 +66,17 @@ func parsePrometheusMetadata(jsonMetadata json.RawMessage) (*prometheusMetadata,
 	return metadata, nil
 }
 
+// golang issue: https://github.com/golang/go/issues/4013
+func queryEscape(query string) string {
+	queryEscaped := url.QueryEscape(query)
+	plusEscaped := strings.ReplaceAll(queryEscaped, "+", "%20")
+
+	return plusEscaped
+}
+
 func (s *prometheusScaler) executePromQuery(ctx context.Context, query string) (float64, error) {
 	t := time.Now().UTC().Format(time.RFC3339)
-	queryEscaped := url.QueryEscape(query)
+	queryEscaped := queryEscape(query)
 	queryURL := fmt.Sprintf("%s/api/v1/query?query=%s&time=%s", s.metadata.ServerAddress, queryEscaped, t)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", queryURL, nil)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -15,6 +15,7 @@ This directory contains an End-to-End (E2E) testing framework for the Elasti Kub
 - [Kind](https://kind.sigs.k8s.io/) (Kubernetes in Docker) v0.17.0+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.25.0+
 - [kuttl](https://kuttl.dev/) v0.15.0+
+- [jq](https://jqlang.org/) v1.7+
 
   ```bash
     # Using Krew (Kubernetes plugin manager)

--- a/tests/e2e/kuttl-test.yaml
+++ b/tests/e2e/kuttl-test.yaml
@@ -6,6 +6,8 @@ testDirs:
 timeout: 60
 parallel: 1
 commands:
+  - command: kubectl apply -f ./manifest/pod-curl-target-gw.yaml -n target
+    namespaced: false
   - command: kubectl apply -f ./manifest/istio-gateway.yaml -n istio-system
     namespaced: false
   - command: kubectl apply -f ./manifest/target-deployment.yaml -n target

--- a/tests/e2e/manifest/pod-curl-target-gw.yaml
+++ b/tests/e2e/manifest/pod-curl-target-gw.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: curl-target-gw
+  namespace: target
+  labels:
+    app: curl-target-gw
+spec:
+  containers:
+    - name: curl
+      image: ghcr.io/curl/curl-container/curl:master
+      command: [ "sleep" ]
+      args: [ "infinity" ]

--- a/tests/e2e/manifest/reset.sh
+++ b/tests/e2e/manifest/reset.sh
@@ -2,16 +2,13 @@
 
 # NOTE: We are taking the argument as the path to the manifest directory.
 # This is needed as the script is called from multiple places and has different paths.
-# Maybe in future we can fix this, but for now this is fine. 
+# Maybe in future we can fix this, but for now this is fine.
 
 # Apply ElastiService
-kubectl apply -f  $1/target-elastiservice.yaml -n target
+kubectl apply -f  "$1/target-elastiservice.yaml" -n target
 
-# Scale target-deployment back to 1
-kubectl scale deployment target-deployment -n target --replicas=1
-
-# Reset the service selector and port
-kubectl patch service target-deployment -n target --type=merge -p '{"spec":{"selector":{"app":"target-deployment"},"ports":[{"port":80,"targetPort":8080}]}}'
+# Reset target deployment, service & ingress back to defaults
+kubectl replace -f "$1/target-deployment.yaml" -n target
 
 # Scale elasti-resolver back to 1
 kubectl scale deployment elasti-resolver -n elasti --replicas=1

--- a/tests/e2e/manifest/target-elastiservice.yaml
+++ b/tests/e2e/manifest/target-elastiservice.yaml
@@ -5,7 +5,7 @@ metadata:
   name: target-elastiservice
   namespace: target
 spec:
-  cooldownPeriod: 5
+  cooldownPeriod: 30
   minTargetReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1

--- a/tests/e2e/tests/01-enable-proxy-via-manual/00-scale-to-0-target.yaml
+++ b/tests/e2e/tests/01-enable-proxy-via-manual/00-scale-to-0-target.yaml
@@ -1,13 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: target-deployment
-  namespace: target
-spec:
-  replicas: 0
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+commands:
+  - command: kubectl scale deployment/target-deployment -n target --replicas=0
+  - command: kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s

--- a/tests/e2e/tests/02-enable-serve-via-traffic/00-scale-to-0-target.yaml
+++ b/tests/e2e/tests/02-enable-serve-via-traffic/00-scale-to-0-target.yaml
@@ -1,13 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: target-deployment
-  namespace: target
-spec:
-  replicas: 0
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+commands:
+  - command: kubectl scale deployment/target-deployment -n target --replicas=0
+  - command: kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s

--- a/tests/e2e/tests/02-enable-serve-via-traffic/01-send-traffic.yaml
+++ b/tests/e2e/tests/02-enable-serve-via-traffic/01-send-traffic.yaml
@@ -1,10 +1,16 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  for i in 1 2 3 4 5; do
-    code=$(curl -s -o /dev/null -w "%{http_code}" http://target-deployment.target.svc.cluster.local:8080)
-    echo "$code"
-    if [ "$code" != "200" ]; then exit 1; fi
-    sleep 1
-  done
+commands:
+  - script: |
+      #!/bin/sh
+      for i in 1 2 3 4 5; do
+        code=$(kubectl exec -n target curl-target-gw -- curl --max-time 30 -s -o /dev/null -w "%{http_code}" http://target-deployment.target.svc.cluster.local/bytes/1048576)
+        result=$?
+
+        echo "$result / $code"
+
+        # if [ "$result" != "0" ]; then exit 1; fi
+        if [ "$code" != "200" ]; then exit 2; fi
+
+        sleep 1
+      done

--- a/tests/e2e/tests/02-enable-serve-via-traffic/02-wait-ready.yaml
+++ b/tests/e2e/tests/02-enable-serve-via-traffic/02-wait-ready.yaml
@@ -1,5 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=60s
+commands:
+  - command: kubectl wait --for=condition=Ready pods -l app=target-deployment -n target --timeout=60s

--- a/tests/e2e/tests/03-enable-serve-via-manual/00-scale-to-0-target.yaml
+++ b/tests/e2e/tests/03-enable-serve-via-manual/00-scale-to-0-target.yaml
@@ -1,13 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: target-deployment
-  namespace: target
-spec:
-  replicas: 0
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+commands:
+  - command: kubectl scale deployment/target-deployment -n target --replicas=0
+  - command: kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s

--- a/tests/e2e/tests/03-enable-serve-via-manual/01-manual-scale.yaml
+++ b/tests/e2e/tests/03-enable-serve-via-manual/01-manual-scale.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl scale deployment target-deployment -n target --replicas=1
-  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=60s
+commands:
+  - command: kubectl scale deployment/target-deployment -n target --replicas=1
+  - command: kubectl wait --for=condition=Ready pods -l app=target-deployment -n target --timeout=60s

--- a/tests/e2e/tests/04-public-private-svc-sync/01-scale-to-0-target.yaml
+++ b/tests/e2e/tests/04-public-private-svc-sync/01-scale-to-0-target.yaml
@@ -1,13 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: target-deployment
-  namespace: target
-spec:
-  replicas: 0
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+commands:
+  - command: kubectl scale deployment/target-deployment -n target --replicas=0
+  - command: kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s

--- a/tests/e2e/tests/05-elasti-crd-remove/00-scale-target.yaml
+++ b/tests/e2e/tests/05-elasti-crd-remove/00-scale-target.yaml
@@ -1,21 +1,7 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: target-deployment
-  namespace: target
-spec:
-  replicas: 0
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: target-deployment
-  namespace: target
-spec:
-  replicas: 1
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=60s
+commands:
+  - command: kubectl scale deployment/target-deployment -n target --replicas=0
+  - command: kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s
+  - command: kubectl scale deployment/target-deployment -n target --replicas=1
+  - command: kubectl wait --for=condition=Ready pods -l app=target-deployment -n target --timeout=60s

--- a/tests/e2e/tests/05-elasti-crd-remove/03-reset.yaml
+++ b/tests/e2e/tests/05-elasti-crd-remove/03-reset.yaml
@@ -1,7 +1,3 @@
-#I know this is weird, but we are doing it: 
-# - To get controller to create the private service. 
-# - It doesn't create it unless the proxy hasn't been enabled atleast once. 
-
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:

--- a/tests/e2e/tests/06-resolver-endpoint-sync/01-scale-to-0-target.yaml
+++ b/tests/e2e/tests/06-resolver-endpoint-sync/01-scale-to-0-target.yaml
@@ -1,13 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: target-deployment
-  namespace: target
-spec:
-  replicas: 0
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+commands:
+  - command: kubectl scale deployment/target-deployment -n target --replicas=0
+  - command: kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s

--- a/tests/e2e/tests/06-resolver-endpoint-sync/03-check-endpointslice-has-resolver-ips.yaml
+++ b/tests/e2e/tests/06-resolver-endpoint-sync/03-check-endpointslice-has-resolver-ips.yaml
@@ -1,26 +1,27 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  # Verify that the endpointslice contains resolver IPs
+commands:
+  - script: |
+      #!/bin/sh
+      # Verify that the endpointslice contains resolver IPs
 
-  # Get resolver pod IPs
-  RESOLVER_IPS=$(kubectl get pods -n elasti -l app=elasti-resolver -o jsonpath='{.items[*].status.podIP}')
+      # Get resolver pod IPs
+      RESOLVER_IPS=$(kubectl get pods -n elasti -l app=elasti-resolver -o jsonpath='{.items[*].status.podIP}')
 
-  # Check if resolver IPs are present in the endpointslice
-  ENDPOINTSLICE_IPS=$(kubectl get endpointslice -n target elasti-target-deployment-endpointslice-to-resolver-9696239e87 -o jsonpath='{.endpoints[*].addresses[*]}')
+      # Check if resolver IPs are present in the endpointslice
+      ENDPOINTSLICE_IPS=$(kubectl get endpointslice -n target elasti-target-deployment-endpointslice-to-resolver-9696239e87 -o jsonpath='{.endpoints[*].addresses[*]}')
 
-  # Verify that the endpointslice contains at least one resolver IP
-  echo "Resolver IPs: $RESOLVER_IPS"
-  echo "EndpointSlice IPs: $ENDPOINTSLICE_IPS"
+      # Verify that the endpointslice contains at least one resolver IP
+      echo "Resolver IPs: $RESOLVER_IPS"
+      echo "EndpointSlice IPs: $ENDPOINTSLICE_IPS"
 
-  # Check if any resolver IP is in the endpointslice
-  for IP in $RESOLVER_IPS; do
-    if echo "$ENDPOINTSLICE_IPS" | grep -q "$IP"; then
-      echo "Found resolver IP $IP in endpointslice"
-      exit 0
-    fi
-  done
+      # Check if any resolver IP is in the endpointslice
+      for IP in $RESOLVER_IPS; do
+        if echo "$ENDPOINTSLICE_IPS" | grep -q "$IP"; then
+          echo "Found resolver IP $IP in endpointslice"
+          exit 0
+        fi
+      done
 
-  echo "No resolver IPs found in endpointslice"
-  exit 1
+      echo "No resolver IPs found in endpointslice"
+      exit 1

--- a/tests/e2e/tests/06-resolver-endpoint-sync/04-scale-to-0-resolver.yaml
+++ b/tests/e2e/tests/06-resolver-endpoint-sync/04-scale-to-0-resolver.yaml
@@ -1,13 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: elasti-resolver
-  namespace: elasti
-spec:
-  replicas: 0
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  kubectl wait --for=delete pods -l app=elasti-resolver -n elasti --timeout=60s || exit 1
+commands:
+  - command: kubectl scale deployment/elasti-resolver -n elasti --replicas=0
+  - command: kubectl wait --for=delete pods -l app=elasti-resolver -n elasti --timeout=60s

--- a/tests/e2e/tests/06-resolver-endpoint-sync/05-check-endpointslice-with-resolver-scaled-to-0.yaml
+++ b/tests/e2e/tests/06-resolver-endpoint-sync/05-check-endpointslice-with-resolver-scaled-to-0.yaml
@@ -1,24 +1,25 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-script: |
-  #!/bin/sh
-  # Verify that when resolver is scaled to 0, the endpointslice remains unchanged
+commands:
+  - script: |
+      #!/bin/sh
+      # Verify that when resolver is scaled to 0, the endpointslice remains unchanged
 
-  # Check if the endpointslice still exists (it should)
-  kubectl get endpointslice -n target elasti-target-deployment-endpointslice-to-resolver-9696239e87 -o jsonpath='{.metadata.name}' | grep "elasti-target-deployment-endpointslice-to-resolver-9696239e87" || exit 1
+      # Check if the endpointslice still exists (it should)
+      kubectl get endpointslice -n target elasti-target-deployment-endpointslice-to-resolver-9696239e87 -o jsonpath='{.metadata.name}' | grep "elasti-target-deployment-endpointslice-to-resolver-9696239e87" || exit 1
 
-  # Get the number of endpoints in the endpointslice
-  # When resolver is scaled to 0, the operator should not modify the endpointslice
-  # as per the requirement: "In case resolver deployments is 0, it should do nothing to the EndpointSlice"
+      # Get the number of endpoints in the endpointslice
+      # When resolver is scaled to 0, the operator should not modify the endpointslice
+      # as per the requirement: "In case resolver deployments is 0, it should do nothing to the EndpointSlice"
 
-  # Check if the endpointslice still has the same endpoints
-  ENDPOINTS_COUNT=$(kubectl get endpointslice -n target elasti-target-deployment-endpointslice-to-resolver-9696239e87 -o jsonpath='{.endpoints}' | jq 'length')
+      # Check if the endpointslice still has the same endpoints
+      ENDPOINTS_COUNT=$(kubectl get endpointslice -n target elasti-target-deployment-endpointslice-to-resolver-9696239e87 -o jsonpath='{.endpoints}' | jq 'length')
 
-  # Verify that the endpointslice still has endpoints (should be unchanged)
-  if [ "$ENDPOINTS_COUNT" -gt 0 ]; then
-    echo "EndpointSlice still has $ENDPOINTS_COUNT endpoints as expected"
-    exit 0
-  else
-    echo "EndpointSlice has no endpoints, which is unexpected"
-    exit 1
-  fi
+      # Verify that the endpointslice still has endpoints (should be unchanged)
+      if [ "$ENDPOINTS_COUNT" -gt 0 ]; then
+        echo "EndpointSlice still has $ENDPOINTS_COUNT endpoints as expected"
+        exit 0
+      else
+        echo "EndpointSlice has no endpoints, which is unexpected"
+        exit 1
+      fi


### PR DESCRIPTION
## Description
E2E tests are misusing `kuttl`, which makes them not really working properly.

Fixes:
- prom query escaping is invalid (due to golang "bug"), same fix is in #153
- `kuttl` doesn't like mixing `TestStep` with anything else
- `TestStep.script` doesn't exists based on https://kuttl.dev/docs/testing/reference.html#teststep
- calling `curl` from inside `commands[].script` doesn't use `kind` network. `curl` pod which acts as gateway was added
- `cooldownPeriod`in CRD has to correlate with metric collection period, otherwise scaler health check is failing
- `deployment/target` is being poisoned in `04-public-private-svc-sync`, so full replace rather than apply is called.

Remarks:
1.~~tests are unstable, as manual scaling is probably interfering with `Elasti`~~ typo in test
2. ~~`02-enable-serve-via-traffic` shows problems with proxy. When deployment is scaled up, proxy isn't forwarding whole response.~~ Converted into #157 


## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [x] e2e testing

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [ ] A PR is open to update the helm chart (link)[https://github.com/truefoundry/elasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL encoding for Prometheus queries to ensure spaces are encoded correctly.

* **Chores**
  * Updated and streamlined end-to-end test manifests and scripts for better clarity and maintainability.
  * Added a new Kubernetes Pod manifest for test scenarios.
  * Increased the cooldown period in ElastiService test configuration.
  * Refactored test steps to use structured command lists instead of shell scripts, improving test readability and consistency.
  * Removed redundant resource definitions and comments from test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->