### PR TITLE
feat: forward source host to target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 0.1.15
 * Add validation for CRD fields for elasti service by @ramantehlan in https://github.com/truefoundry/elasti/pull/122
+* Forward source host to target by @ramantehlan in https://github.com/truefoundry/elasti/pull/123
 
 ## 0.1.14
 * update workflow to update grype config by @DeeAjayi in https://github.com/truefoundry/KubeElasti/pull/113

--- a/playground/infra/elasti-demo-values.yaml
+++ b/playground/infra/elasti-demo-values.yaml
@@ -3,7 +3,7 @@ elastiController:
     image:
       repository: localhost:5001/elasti-operator
       tag: v1alpha1
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Always
     resources:
       limits:
         cpu: 500m
@@ -16,7 +16,7 @@ elastiResolver:
     image:
       repository: localhost:5001/elasti-resolver
       tag: v1alpha1
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Always
     resources:
       limits:
         cpu: 500m

--- a/tests/e2e/kuttl-test.yaml
+++ b/tests/e2e/kuttl-test.yaml
@@ -3,7 +3,7 @@ kind: TestSuite
 startKIND: false
 testDirs:
   - ./tests/
-timeout: 60
+timeout: 120
 parallel: 1
 commands:
   - command: kubectl apply -f ./manifest/istio-gateway.yaml -n istio-system

--- a/tests/e2e/manifest/reset.sh
+++ b/tests/e2e/manifest/reset.sh
@@ -17,6 +17,6 @@ kubectl patch service target-deployment -n target --type=merge -p '{"spec":{"sel
 kubectl scale deployment elasti-resolver -n elasti --replicas=1
 
 # Wait for resources to be ready
-kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=30s
-kubectl wait pods -l app=elasti-resolver -n elasti --for=condition=Ready --timeout=30s
+kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=120s
+kubectl wait pods -l app=elasti-resolver -n elasti --for=condition=Ready --timeout=120s
 kubectl get elastiservice -n target target-elastiservice || exit 1

--- a/tests/e2e/manifest/reset.sh
+++ b/tests/e2e/manifest/reset.sh
@@ -9,14 +9,14 @@ kubectl apply -f  $1/target-elastiservice.yaml -n target
 
 # Scale target-deployment back to 1
 kubectl scale deployment target-deployment -n target --replicas=1
+kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=120s
 
 # Reset the service selector and port
 kubectl patch service target-deployment -n target --type=merge -p '{"spec":{"selector":{"app":"target-deployment"},"ports":[{"port":80,"targetPort":8080}]}}'
 
 # Scale elasti-resolver back to 1
 kubectl scale deployment elasti-resolver -n elasti --replicas=1
+kubectl wait pods -l app=elasti-resolver -n elasti --for=condition=Ready --timeout=120s
 
 # Wait for resources to be ready
-kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=120s
-kubectl wait pods -l app=elasti-resolver -n elasti --for=condition=Ready --timeout=120s
 kubectl get elastiservice -n target target-elastiservice || exit 1

--- a/tests/e2e/tests/01-enable-proxy-via-manual/00-scale-to-0-target.yaml
+++ b/tests/e2e/tests/01-enable-proxy-via-manual/00-scale-to-0-target.yaml
@@ -10,4 +10,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 script: |
   #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=120s || exit 1

--- a/tests/e2e/tests/02-enable-serve-via-traffic/00-scale-to-0-target.yaml
+++ b/tests/e2e/tests/02-enable-serve-via-traffic/00-scale-to-0-target.yaml
@@ -10,4 +10,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 script: |
   #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=120s || exit 1

--- a/tests/e2e/tests/02-enable-serve-via-traffic/02-wait-ready.yaml
+++ b/tests/e2e/tests/02-enable-serve-via-traffic/02-wait-ready.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 script: |
   #!/bin/sh
-  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=60s
+  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=120s

--- a/tests/e2e/tests/03-enable-serve-via-manual/00-scale-to-0-target.yaml
+++ b/tests/e2e/tests/03-enable-serve-via-manual/00-scale-to-0-target.yaml
@@ -10,4 +10,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 script: |
   #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=120s || exit 1

--- a/tests/e2e/tests/03-enable-serve-via-manual/01-manual-scale.yaml
+++ b/tests/e2e/tests/03-enable-serve-via-manual/01-manual-scale.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 script: |
   #!/bin/sh
   kubectl scale deployment target-deployment -n target --replicas=1
-  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=60s
+  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=120s

--- a/tests/e2e/tests/04-public-private-svc-sync/01-scale-to-0-target.yaml
+++ b/tests/e2e/tests/04-public-private-svc-sync/01-scale-to-0-target.yaml
@@ -10,4 +10,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 script: |
   #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=120s || exit 1

--- a/tests/e2e/tests/05-elasti-crd-remove/00-scale-target.yaml
+++ b/tests/e2e/tests/05-elasti-crd-remove/00-scale-target.yaml
@@ -18,4 +18,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 script: |
   #!/bin/sh
-  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=60s
+  kubectl wait pods -l app=target-deployment -n target --for=condition=Ready --timeout=120s

--- a/tests/e2e/tests/06-resolver-endpoint-sync/01-scale-to-0-target.yaml
+++ b/tests/e2e/tests/06-resolver-endpoint-sync/01-scale-to-0-target.yaml
@@ -10,4 +10,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 script: |
   #!/bin/sh
-  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=60s || exit 1
+  kubectl wait --for=delete pods -l app=target-deployment -n target --timeout=120s || exit 1

--- a/tests/e2e/tests/06-resolver-endpoint-sync/04-scale-to-0-resolver.yaml
+++ b/tests/e2e/tests/06-resolver-endpoint-sync/04-scale-to-0-resolver.yaml
@@ -10,4 +10,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 script: |
   #!/bin/sh
-  kubectl wait --for=delete pods -l app=elasti-resolver -n elasti --timeout=60s || exit 1
+  kubectl wait --for=delete pods -l app=elasti-resolver -n elasti --timeout=120s || exit 1


### PR DESCRIPTION
## Description

When target does a redirection(using 302 etc), they use the incoming host for it. 
However, while resolver proxy the request, it reset host to private service, which is not accessible to public by default, and the redirection fails.

This PR stops the resetting of host in resolver, so the request appears to be coming from the source to the target, and not from the proxy. 

Fixes #145 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [x] Tested using HttpBin to see if the host remains same for the request. 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [ ] A PR is open to update the helm chart (link)[https://github.com/truefoundry/elasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for forwarding the original source host to the target during proxying.

* **Documentation**
  * Updated instructions to use the new Kubernetes namespace naming, simplified deployment steps, and added detailed debugging and redeployment guidance.

* **Bug Fixes**
  * Improved proxy error handling to log errors and return appropriate HTTP responses instead of panicking.

* **Chores**
  * Changed image pull policy to always fetch the latest container images on deployment.
  * Increased timeout durations in end-to-end tests and scripts to improve stability during pod readiness and deletion waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->