### PR TITLE
resolver: migrate to EndpointSlice API

### DIFF
--- a/charts/elasti/templates/deployment.yaml
+++ b/charts/elasti/templates/deployment.yaml
@@ -134,3 +134,4 @@ spec:
         - containerPort: {{ .Values.elastiResolver.reverseProxyService.port }}
         resources: 
           {{- toYaml .Values.elastiResolver.proxy.resources | nindent 10 }}
+      serviceAccountName: {{ include "elasti.fullname" . }}-resolver

--- a/charts/elasti/templates/resolver-additional-access-binding-rbac.yaml
+++ b/charts/elasti/templates/resolver-additional-access-binding-rbac.yaml
@@ -10,5 +10,5 @@ roleRef:
   name: {{ include "elasti.fullname" . }}-resolver-additional-access
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ include "elasti.fullname" . }}-resolver
   namespace: '{{ .Release.Namespace }}'

--- a/charts/elasti/templates/resolver-additional-access-rbac.yaml
+++ b/charts/elasti/templates/resolver-additional-access-rbac.yaml
@@ -5,9 +5,6 @@ metadata:
   labels:
     {{- include "elasti.labels" . | nindent 4 }}
 rules:
-- apiGroups: ["apps"]
-  resources: ["deployments"]
-  verbs: ["get", "list", "watch", "update", "patch"]
-- apiGroups: [""]
-  resources: ["services", "pods", "endpoints"]
-  verbs: ["get", "list", "watch", "update", "patch", "delete", "create"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["list"]

--- a/charts/elasti/templates/serviceaccount.yaml
+++ b/charts/elasti/templates/serviceaccount.yaml
@@ -7,3 +7,13 @@ metadata:
     {{- include "elasti.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.elastiController.serviceAccount.annotations | nindent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "elasti.fullname" . }}-resolver
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    {{- include "elasti.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.elastiResolver.serviceAccount.annotations | nindent 4 }}

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -68,6 +68,8 @@ elastiResolver:
       enabled: false
       environment: ""
   replicas: 1
+  serviceAccount:
+    annotations: {}
   autoscaling:
     enabled: false
     minReplicas: 1

--- a/resolver/internal/throttler/throttler.go
+++ b/resolver/internal/throttler/throttler.go
@@ -99,7 +99,7 @@ func (t *Throttler) checkIfServiceReady(namespace, service string) (bool, error)
 		return ready.(bool), nil
 	}
 
-	isPodActive, err := t.k8sUtil.CheckIfServiceEndpointActive(namespace, service)
+	isPodActive, err := t.k8sUtil.CheckIfServiceEndpointSliceActive(namespace, service)
 	if err != nil {
 		return false, fmt.Errorf("unable to get target active endpoints: %w", err)
 	}


### PR DESCRIPTION
## Description
Resolver is using deprecated Endpoint API (as for kubernetes 1.33), which should be replaced with EndpointSlice API (just like operator uses).
This PR also adds separate ServiceAccount for resolver (it was using default) and cleans up RBAC permissions for it. 

Fixes #164 

## Type of change
Please delete options that are not relevant.

- [x Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [x] local testing

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [ ] A PR is open to update the helm chart (link)[https://github.com/truefoundry/elasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
