### PR TITLE
release: 0.1.15

### DIFF
--- a/charts/elasti/Chart.yaml
+++ b/charts/elasti/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: elasti
 description: Helm chart for Elasti application
 type: application
-version: 0.1.15-beta
-appVersion: "0.1.15-beta"
+version: 0.1.15
+appVersion: "0.1.15"

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -17,7 +17,7 @@ elastiController:
           - ALL
     image:
       repository: tfy.jfrog.io/tfy-images/elasti-operator
-      tag: 0.1.15-beta
+      tag: 0.1.15
     imagePullPolicy: IfNotPresent
     resources:
       limits:
@@ -55,7 +55,7 @@ elastiResolver:
       trafficReEnableDuration: "5"
     image:
       repository: tfy.jfrog.io/tfy-images/elasti-resolver
-      tag: 0.1.15-beta
+      tag: 0.1.15
     imagePullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
🚀 KubeElasti v0.1.15 is LIVE! 🎉

We’re thrilled to roll out KubeElasti v0.1.15, a major step toward making scale-to-zero on Kubernetes more reliable, battle-tested, and developer-friendly. This release brings foundational improvements and sets the tone for a more robust future.

Here’s what’s new:

✅ End-to-End (E2E) Testing Introduced – Every release now runs through automated, production-like validation before it ships.
✅ Staged Beta Testing – All beta releases are deployed and tested in TrueFoundry’s internal environments before tagging stable.
🌐 New Homepage Launched – Check out the fresh new face of KubeElasti: https://kubeelasti.dev/
🛡️ Improved CRD Validation – Smarter schema checks for catching errors early in your manifests.
🛠️ Critical Bug Fixes + Roadmap Visibility – We’ve squashed several high-priority bugs and surfaced areas for future enhancement.

Join us by reporting issues, suggest features, or send a PR. Feedback and contributions are always welcome!

---

## Fixes
* Forward source host to target by @ramantehlan in https://github.com/truefoundry/elasti/pull/159

## Improvements
* Supporting second level cooldown period for prometheus uptime check by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/125
* Add validation for CRD fields for elasti service by @ramantehlan in https://github.com/truefoundry/elasti/pull/138

## Other
* Add E2E tests via Kuttl by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/123
* Add Docs for KubeElasti at https://kubeelasti.dev by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/142
* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /pkg in https://github.com/truefoundry/KubeElasti/pull/156
* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /operator in https://github.com/truefoundry/KubeElasti/pull/155
* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /resolver in https://github.com/truefoundry/KubeElasti/pull/151
* Security Fix: Bump golang.org/x/net from 0.33.0 to 0.38.0 in /pkg in https://github.com/truefoundry/KubeElasti/pull/143
* Release: Updated stable and beta release steps. by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/165
* e2e: fix test issues by @rethil in https://github.com/truefoundry/KubeElasti/pull/154

## New Contributors
* @rethil made their first contribution in https://github.com/truefoundry/KubeElasti/pull/154

**Full Changelog**: https://github.com/truefoundry/KubeElasti/compare/elasti-helm-v0.1.14...v0.1.15-beta