### PR TITLE
operator: support installation in any namespace

### DIFF
--- a/charts/elasti/templates/deployment.yaml
+++ b/charts/elasti/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
           value: {{ .Values.global.kubernetesClusterDomain }}
         - name: POLLING_INTERVAL
           value: {{ .Values.elastiController.manager.env.pollingInterval | quote }}
+        - name: ELASTI_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         {{- if .Values.elastiController.manager.sentry.enabled }}
         - name: SENTRY_DSN
           valueFrom:

--- a/operator/internal/controller/elastiservice_controller.go
+++ b/operator/internal/controller/elastiservice_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -44,10 +45,14 @@ const (
 
 	// These are resolver details, ideally in future we can move this to a configmap, or find a better way to serve this
 	// TODO: Move this to configmap
-	resolverNamespace      = "elasti"
 	resolverDeploymentName = "elasti-resolver"
 	resolverServiceName    = "elasti-resolver-service"
 	resolverPort           = 8012
+)
+
+var (
+	// TODO: move this to configmap as const above
+	resolverNamespace = os.Getenv("ELASTI_POD_NAMESPACE")
 )
 
 //+kubebuilder:rbac:groups=elasti.truefoundry.com,resources=elastiservices,verbs=get;list;watch;create;update;patch;delete

--- a/operator/internal/informer/informer.go
+++ b/operator/internal/informer/informer.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -30,10 +31,14 @@ import (
 
 const (
 	// TODO: Move to configMap
-	resolverNamespace      = "elasti"
 	resolverDeploymentName = "elasti-resolver"
 	resolverServiceName    = "elasti-resolver-service"
 	resolverPort           = 8012
+)
+
+var (
+	// TODO: move this to configmap as const above
+	resolverNamespace = os.Getenv("ELASTI_POD_NAMESPACE")
 )
 
 type (


### PR DESCRIPTION
## Description
This allows operator to work in any namespace, not only in `elasti`.

Fixes #175

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] e2e
- [x] local k3s cluster

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [ ] A PR is open to update the helm chart (link)[https://github.com/truefoundry/elasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
