### PR TITLE
copying over private service ports from public service directly

### DIFF
--- a/operator/internal/controller/opsServices.go
+++ b/operator/internal/controller/opsServices.go
@@ -92,13 +92,8 @@ func (r *ElastiServiceReconciler) handlePublicServiceChanges(ctx context.Context
 
 	// Sync the changes in private service
 	privateSVC.Spec.Selector = publicSVC.Spec.Selector
-	for port := range privateSVC.Spec.Ports {
-		privateSVC.Spec.Ports[port].Name = publicSVC.Spec.Ports[port].Name
-		privateSVC.Spec.Ports[port].Protocol = publicSVC.Spec.Ports[port].Protocol
-		privateSVC.Spec.Ports[port].Port = publicSVC.Spec.Ports[port].Port
-		privateSVC.Spec.Ports[port].TargetPort = publicSVC.Spec.Ports[port].TargetPort
-		privateSVC.Spec.Ports[port].AppProtocol = publicSVC.Spec.Ports[port].AppProtocol
-	}
+	privateSVC.Spec.Ports = make([]v1.ServicePort, len(publicSVC.Spec.Ports))
+	copy(privateSVC.Spec.Ports, publicSVC.Spec.Ports)
 
 	// Update the private service
 	if err := r.Update(ctx, privateSVC); err != nil {

--- a/operator/internal/controller/opsServices.go
+++ b/operator/internal/controller/opsServices.go
@@ -94,6 +94,9 @@ func (r *ElastiServiceReconciler) handlePublicServiceChanges(ctx context.Context
 	privateSVC.Spec.Selector = publicSVC.Spec.Selector
 	privateSVC.Spec.Ports = make([]v1.ServicePort, len(publicSVC.Spec.Ports))
 	copy(privateSVC.Spec.Ports, publicSVC.Spec.Ports)
+	for port := range privateSVC.Spec.Ports {
+		privateSVC.Spec.Ports[port].NodePort = 0
+	}
 
 	// Update the private service
 	if err := r.Update(ctx, privateSVC); err != nil {


### PR DESCRIPTION
## Description
Reducing the number of ports from public service after creation crashes the application

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Service port configurations now update atomically so private services precisely mirror public service ports and clear any node-assigned ports, reducing mismatches and unintended port exposure.

- Refactor
  - Port synchronization simplified to replace entire port sets at once, improving update consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->