### PR TITLE
release: 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,77 +4,60 @@
     Please refer to https://github.com/truefoundry/KubeElasti/blob/main/CONTRIBUTING.md#Changelog and follow the guidelines before adding a new entry.
 -->
 
-## 0.1.16
+## 0.1.16 (2025-09-22)
 
 ### Fixes 
-* fix: first response content after scaling up is truncated by @rethil in https://github.com/truefoundry/KubeElasti/pull/163
-* copying over private service ports from public service directly by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/190
-* fix 02 e2e test, which was because of incorrect readiness check of endpointslice.  by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/189
+* fix: first response content after scaling up is truncated by @rethil in [#163](https://github.com/truefoundry/KubeElasti/pull/163)
+* copying over private service ports from public service directly by @shubhamrai1993 in [#190](https://github.com/truefoundry/KubeElasti/pull/190)
+* fix 02 e2e test, which was because of incorrect readiness check of endpointslice.  by @ramantehlan in [#189](https://github.com/truefoundry/KubeElasti/pull/189)
 
 ### Improvements
-* prometheus scaler: make healthcheck customizable by @rethil in https://github.com/truefoundry/KubeElasti/pull/153
-* resolver: use distroless/static as base image by @rethil in https://github.com/truefoundry/KubeElasti/pull/181
-* resolver: migrate to EndpointSlice API by @rethil in https://github.com/truefoundry/KubeElasti/pull/167
-* security: cleanup roles in helm chart by @rethil in https://github.com/truefoundry/KubeElasti/pull/179
+* prometheus scaler: make healthcheck customizable by @rethil in [#153](https://github.com/truefoundry/KubeElasti/pull/153)
+* resolver: use distroless/static as base image by @rethil in [#181](https://github.com/truefoundry/KubeElasti/pull/181)
+* resolver: migrate to EndpointSlice API by @rethil in [#167](https://github.com/truefoundry/KubeElasti/pull/167)
+* security: cleanup roles in helm chart by @rethil in [#179](https://github.com/truefoundry/KubeElasti/pull/179)
 
 ### Other
-* Docs: Add demo video - Contributors section - Discord link by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/172
-* Add announcement and FAQ to the docs by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/177
-* fix e2e workflow and tests by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/184
+* Docs: Add demo video - Contributors section - Discord link by @ramantehlan in [#172](https://github.com/truefoundry/KubeElasti/pull/172)
+* Add announcement and FAQ to the docs by @ramantehlan in [#177](https://github.com/truefoundry/KubeElasti/pull/177)
+* fix e2e workflow and tests by @ramantehlan in [#184](https://github.com/truefoundry/KubeElasti/pull/184)
 
 
 ## 0.1.15
-* Add validation for CRD fields for elasti service by @ramantehlan in https://github.com/truefoundry/elasti/pull/122
-* Forward source host to target by @ramantehlan in https://github.com/truefoundry/elasti/pull/123
+* Add validation for CRD fields for elasti service by @ramantehlan in [#122](https://github.com/truefoundry/elasti/pull/122)
+* Forward source host to target by @ramantehlan in [#123](https://github.com/truefoundry/elasti/pull/123)
 
 ## 0.1.15-beta (2025-07-28)
 
 ### Fixes
-* Forward source host to target by @ramantehlan in https://github.com/truefoundry/elasti/pull/159
+* Forward source host to target by @ramantehlan in [#159](https://github.com/truefoundry/elasti/pull/159)
 
 ### Improvements
-* Supporting second level cooldown period for prometheus uptime check by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/125
-* Add validation for CRD fields for elasti service by @ramantehlan in https://github.com/truefoundry/elasti/pull/138
+* Supporting second level cooldown period for prometheus uptime check by @shubhamrai1993 in [#125](https://github.com/truefoundry/KubeElasti/pull/125)
+* Add validation for CRD fields for elasti service by @ramantehlan in [#138](https://github.com/truefoundry/elasti/pull/138)
 
 ### Other
-* Add E2E tests via Kuttl by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/123
-* Add Docs for KubeElasti at https://kubeelasti.dev by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/142
-* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /pkg in https://github.com/truefoundry/KubeElasti/pull/156
-* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /operator in https://github.com/truefoundry/KubeElasti/pull/155
-* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /resolver in https://github.com/truefoundry/KubeElasti/pull/151
-* Security Fix: Bump golang.org/x/net from 0.33.0 to 0.38.0 in /pkg in https://github.com/truefoundry/KubeElasti/pull/143
+* Add E2E tests via Kuttl by @ramantehlan in [#123](https://github.com/truefoundry/KubeElasti/pull/123)
+* Add Docs for KubeElasti at https://kubeelasti.dev by @ramantehlan in [#142](https://github.com/truefoundry/KubeElasti/pull/142)
+* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /pkg in [#156](https://github.com/truefoundry/KubeElasti/pull/156)
+* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /operator in [#155](https://github.com/truefoundry/KubeElasti/pull/155)
+* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /resolver in [#151](https://github.com/truefoundry/KubeElasti/pull/151)
+* Security Fix: Bump golang.org/x/net from 0.33.0 to 0.38.0 in /pkg in [#143](https://github.com/truefoundry/KubeElasti/pull/143)
 
 ### New Contributors
-* @rethil made their first contribution in https://github.com/truefoundry/KubeElasti/pull/154
+* @rethil made their first contribution in [#154](https://github.com/truefoundry/KubeElasti/pull/154)
 
 ## 0.1.14
-* update workflow to update grype config by @DeeAjayi in https://github.com/truefoundry/KubeElasti/pull/113
-* Add support for namespace scoped elasti controller and fixes for cooldown period tracking by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/115
-* Increasing elasti timeout to 10 minutes by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/116
-* corrected the target name being passed by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/118
-* using event recorder for emitting events by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/117
-* dont scale up replicas if the current replicas are greater by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/119
-* fix: port 5000 is used by the systems, using it might be hurdle for u… by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/120
-* dont scale down new service and handle missing prom data by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/121
+* update workflow to update grype config by @DeeAjayi in [#113](https://github.com/truefoundry/KubeElasti/pull/113)
+* Add support for namespace scoped elasti controller and fixes for cooldown period tracking by @shubhamrai1993 in [#115](https://github.com/truefoundry/KubeElasti/pull/115)
+* Increasing elasti timeout to 10 minutes by @shubhamrai1993 in [#116](https://github.com/truefoundry/KubeElasti/pull/116)
+* corrected the target name being passed by @shubhamrai1993 in [#118](https://github.com/truefoundry/KubeElasti/pull/118)
+* using event recorder for emitting events by @shubhamrai1993 in [#117](https://github.com/truefoundry/KubeElasti/pull/117)
+* dont scale up replicas if the current replicas are greater by @shubhamrai1993 in [#119](https://github.com/truefoundry/KubeElasti/pull/119)
+* fix: port 5000 is used by the systems, using it might be hurdle for u… by @ramantehlan in [#120](https://github.com/truefoundry/KubeElasti/pull/120)
+* dont scale down new service and handle missing prom data by @shubhamrai1993 in [#121](https://github.com/truefoundry/KubeElasti/pull/121)
 
 All the unreleased changes are listed under `Unreleased` section.
-
-## History
-
-- [Changelog](#changelog)
-  - [0.1.16](#0116)
-    - [Fixes](#fixes)
-    - [Improvements](#improvements)
-    - [Other](#other)
-  - [0.1.15](#0115)
-  - [0.1.15-beta (2025-07-28)](#0115-beta-2025-07-28)
-    - [Fixes](#fixes-1)
-    - [Improvements](#improvements-1)
-    - [Other](#other-1)
-    - [New Contributors](#new-contributors)
-  - [0.1.14](#0114)
-  - [History](#history)
-  - [Unreleased](#unreleased)
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@
 -->
 
 ## 0.1.16
-* fix: e2e test "02" due to incorrect readiness check of EndpointSlice by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/189
+
+### Fixes 
+* fix: first response content after scaling up is truncated by @rethil in https://github.com/truefoundry/KubeElasti/pull/163
+* copying over private service ports from public service directly by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/190
+* fix 02 e2e test, which was because of incorrect readiness check of endpointslice.  by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/189
+
+### Improvements
+* prometheus scaler: make healthcheck customizable by @rethil in https://github.com/truefoundry/KubeElasti/pull/153
+* resolver: use distroless/static as base image by @rethil in https://github.com/truefoundry/KubeElasti/pull/181
+* resolver: migrate to EndpointSlice API by @rethil in https://github.com/truefoundry/KubeElasti/pull/167
+* security: cleanup roles in helm chart by @rethil in https://github.com/truefoundry/KubeElasti/pull/179
+
+### Other
+* Docs: Add demo video - Contributors section - Discord link by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/172
+* Add announcement and FAQ to the docs by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/177
+* fix e2e workflow and tests by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/184
 
 
 ## 0.1.15
@@ -48,11 +63,14 @@ All the unreleased changes are listed under `Unreleased` section.
 
 - [Changelog](#changelog)
   - [0.1.16](#0116)
-  - [0.1.15](#0115)
-  - [0.1.15-beta (2025-07-28)](#0115-beta-2025-07-28)
     - [Fixes](#fixes)
     - [Improvements](#improvements)
     - [Other](#other)
+  - [0.1.15](#0115)
+  - [0.1.15-beta (2025-07-28)](#0115-beta-2025-07-28)
+    - [Fixes](#fixes-1)
+    - [Improvements](#improvements-1)
+    - [Other](#other-1)
     - [New Contributors](#new-contributors)
   - [0.1.14](#0114)
   - [History](#history)

--- a/charts/elasti/Chart.yaml
+++ b/charts/elasti/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: elasti
 description: Helm chart for Elasti application
 type: application
-version: 0.1.15
-appVersion: "0.1.15"
+version: 0.1.16
+appVersion: "0.1.16"

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -24,7 +24,7 @@ elastiController:
         type: RuntimeDefault
     image:
       repository: tfy.jfrog.io/tfy-images/elasti-operator
-      tag: 0.1.15
+      tag: 0.1.16
     imagePullPolicy: IfNotPresent
     resources:
       limits:
@@ -62,7 +62,7 @@ elastiResolver:
       trafficReEnableDuration: "5"
     image:
       repository: tfy.jfrog.io/tfy-images/elasti-resolver
-      tag: 0.1.15
+      tag: 0.1.16
     imagePullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
## 0.1.16 (2025-09-22)

### Fixes 
* fix: first response content after scaling up is truncated by @rethil in [#163](https://github.com/truefoundry/KubeElasti/pull/163)
* copying over private service ports from public service directly by @shubhamrai1993 in [#190](https://github.com/truefoundry/KubeElasti/pull/190)
* fix 02 e2e test, which was because of incorrect readiness check of endpointslice.  by @ramantehlan in [#189](https://github.com/truefoundry/KubeElasti/pull/189)

### Improvements
* prometheus scaler: make healthcheck customizable by @rethil in [#153](https://github.com/truefoundry/KubeElasti/pull/153)
* resolver: use distroless/static as base image by @rethil in [#181](https://github.com/truefoundry/KubeElasti/pull/181)
* resolver: migrate to EndpointSlice API by @rethil in [#167](https://github.com/truefoundry/KubeElasti/pull/167)
* security: cleanup roles in helm chart by @rethil in [#179](https://github.com/truefoundry/KubeElasti/pull/179)

### Other
* Docs: Add demo video - Contributors section - Discord link by @ramantehlan in [#172](https://github.com/truefoundry/KubeElasti/pull/172)
* Add announcement and FAQ to the docs by @ramantehlan in [#177](https://github.com/truefoundry/KubeElasti/pull/177)
* fix e2e workflow and tests by @ramantehlan in [#184](https://github.com/truefoundry/KubeElasti/pull/184)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - Customizable health checks and updated base image.
  - Migrated to EndpointSlice API and cleaned Helm chart security.
  - Updated container images to 0.1.16 for controller and resolver; chart/app versions bumped.

- Bug Fixes
  - Fixed first-response content truncation, copying of private service ports, and e2e readiness issues.

- Documentation
  - Changelog reorganized into dated Fixes/Improvements/Other sections and standardized PR references; history/navigation simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->