### PR TITLE
added adopters.md to document adopters

### DIFF
--- a/docs/src/adopters.md
+++ b/docs/src/adopters.md
@@ -1,0 +1,17 @@
+# KubeElasti Adopters
+
+This page contains a list of organizations who are using KubeElasti in production or in stages of development.
+
+If you would like to be included in this table, please open an issue and your information will be added.
+
+## Adopters
+
+| Organization | Status | Link | More information |
+|--------------|--------|------|------------------|
+| Truefoundry | Production | [link](https://truefoundry.com/) | Used as part of the Truefoundry platform |
+| Automation Anywhere | Development | [link](https://www.automationanywhere.com/) | Used as part of the Truefoundry platform |
+| Adopt AI | Development | [link](https://adopt.ai/) | Used as part of the Truefoundry platform |
+| Aviso AI | Development | [link](https://aviso.com/) | Used as part of the Truefoundry platform |
+| Brainfish AI | Development | [link](https://brainfishai.com/) | Used as part of the Truefoundry platform |
+| Prodigal Tech | Development | [link](https://prodigaltech.com/) | Used as part of the Truefoundry platform |
+| Zurich Labs | Production | [link](https://zurichlabs.ai/) | Used as part of the Truefoundry platform |

--- a/docs/src/adopters.md
+++ b/docs/src/adopters.md
@@ -8,11 +8,11 @@ If you would like to be included in this table, please open an issue and your in
 
 | Organization | Status | Link | More information |
 |--------------|--------|------|------------------|
-| Truefoundry | Production | [link](https://truefoundry.com/) | Used as part of the Truefoundry platform |
-| Automation Anywhere | Development | [link](https://www.automationanywhere.com/) | Used as part of the Truefoundry platform |
-| Adopt AI | Development | [link](https://adopt.ai/) | Used as part of the Truefoundry platform |
-| Aviso AI | Development | [link](https://aviso.com/) | Used as part of the Truefoundry platform |
-| Brainfish AI | Development | [link](https://brainfishai.com/) | Used as part of the Truefoundry platform |
-| Prodigal Tech | Development | [link](https://prodigaltech.com/) | Used as part of the Truefoundry platform |
-| Zurich Lab | Production | [link](https://www.zurichlab.in) | Used as part of the Truefoundry platform |
-| VXPlain | Production | [link](https://www.vxplain.com/) | Uses kubeelasti for scale to zero |
+| Truefoundry | Production | [truefoundry.com](https://truefoundry.com/) | Used as part of the Truefoundry platform |
+| Automation Anywhere | Development | [automationanywhere.com](https://www.automationanywhere.com/) | Used as part of the Truefoundry platform |
+| Adopt AI | Development | [adopt.ai](https://adopt.ai/) | Used as part of the Truefoundry platform |
+| Aviso AI | Development | [aviso.com](https://aviso.com/) | Used as part of the Truefoundry platform |
+| Brainfish AI | Development | [brainfishai.com](https://brainfishai.com/) | Used as part of the Truefoundry platform |
+| Prodigal Tech | Development | [prodigaltech.com](https://prodigaltech.com/) | Used as part of the Truefoundry platform |
+| Zurich Lab | Production | [zurichlab.in](https://www.zurichlab.in) | Used as part of the Truefoundry platform |
+| VXPlain | Production | [vxplain.com](https://www.vxplain.com/) | Uses kubeelasti for scale to zero |

--- a/docs/src/adopters.md
+++ b/docs/src/adopters.md
@@ -14,4 +14,5 @@ If you would like to be included in this table, please open an issue and your in
 | Aviso AI | Development | [link](https://aviso.com/) | Used as part of the Truefoundry platform |
 | Brainfish AI | Development | [link](https://brainfishai.com/) | Used as part of the Truefoundry platform |
 | Prodigal Tech | Development | [link](https://prodigaltech.com/) | Used as part of the Truefoundry platform |
-| Zurich Labs | Production | [link](https://zurichlabs.ai/) | Used as part of the Truefoundry platform |
+| Zurich Lab | Production | [link](https://www.zurichlab.in) | Used as part of the Truefoundry platform |
+| VXPlain | Production | [link](https://www.vxplain.com/) | Uses kubeelasti for scale to zero |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,5 +141,6 @@ nav:
       - Test Monitoring: src/dev-test-monitoring.md
       - Contributors: src/dev-contributors.md
   - Comparisons: src/comparisons.md
+  - Adopters: src/adopters.md
   - Blog: 
       - Blog: blog/index.md


### PR DESCRIPTION
## Description
Adding adopters.md

Fixes # (issue)

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- [x] Ran local `make serve-docs`

## Checklist:
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Adopters” page showcasing organizations using KubeElasti, with a table (Organization, Status, Link, More info).
  * Included initial entries: Truefoundry, Automation Anywhere, Adopt AI, Aviso AI, Brainfish AI, Prodigal Tech, Zurich Lab, and VXPlain.
  * Provided instructions for requesting inclusion via an issue.
  * Updated site navigation to surface the new Adopters page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->